### PR TITLE
fix/minor-bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 build:
 	go build -o ./bin/ ./cmd/devx
+
+.PHONY: build

--- a/cmd/devx/do.go
+++ b/cmd/devx/do.go
@@ -6,8 +6,9 @@ import (
 )
 
 var doCmd = &cobra.Command{
-	Use:   "do",
+	Use:   "do [environment]",
 	Short: "do DevX magic for the specified environment",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := client.Run(args[0], configDir, stackPath, buildersPath); err != nil {
 			return err


### PR DESCRIPTION
This PR fixes the following issues:
- [x] Makefile reports the target as up-to-date if `build` file or directory exists, solved by marking target as PHONY
- [x] `devx do` command crashes if no arguments are supplied
- [x] ~~Errors are printed twice~~